### PR TITLE
Remove link to sold kicad-pcb page.

### DIFF
--- a/docsrc/pelicansite/content/pages/landing.md
+++ b/docsrc/pelicansite/content/pages/landing.md
@@ -183,7 +183,7 @@ $ pip install skidl
 ```
 
 To give SKiDL some part libraries to work with,
-you'll also need to install [KiCad](http://kicad-pcb.org/).
+you'll also need to install [KiCad](http://kicad.org/).
 Then, you'll need to set an environment variable so SKiDL can find the libraries.
 For Windows, do this:
 


### PR DESCRIPTION
The URL kicad-pcb[.]org was sold off, kicad.org is the primary domain now.

https://forum.kicad.info/t/warning-avoid-all-links-to-kicad-pcb-org-use-kicad-org/31521