### PR TITLE
feat: Part.pins sorted by pin number.

### DIFF
--- a/skidl/part.py
+++ b/skidl/part.py
@@ -109,7 +109,7 @@ class SortedPinList(UserList):
         self._sort()
 
     def _sort(self):
-        self.data.sort(key=lambda p: getattr(p, "num", "999").zfill(3))
+        self.data.sort(key=lambda p: str(getattr(p, "num", "999")).zfill(3))
 
     def _wrapper(self, method, *args):
         x = getattr(super(), method)(*args)

--- a/tests/test_pin_num_name.py
+++ b/tests/test_pin_num_name.py
@@ -26,3 +26,10 @@ def test_pin_names_2():
     assert codec.p["A1"] is codec.n["A2"]
     assert codec["A1"] is codec.n["A2"]
     assert codec["A1"] is codec.p["A1"]
+
+
+def test_pin_order():
+    codec = Part("xess.lib", "ak4520a")
+    p = codec.pins.pop(12)
+    codec.pins.append(p)
+    assert [int(p.num) for p in codec.pins] == list(range(1, len(codec.pins) + 1))


### PR DESCRIPTION
This PR sorts `Part.pins` by natural pin number (placing unsorted pins at the end).  This means that one can then iterate the .pins as one would expect, without needing to do things like `Part[n] for n in range(len(part.pins))`

*however* this will break any code which expects the last entry in .pins to be what it just put there.

Another option to get the same functionality would be a method like `.ordered_pins()`.

Is this something you'd like to see in skidl?  It's a bit of a hack, but then skidl itself is a wonderful hack :D