### PR TITLE
Should fix #124

### DIFF
--- a/skidl/tools/kicad/kicad.py
+++ b/skidl/tools/kicad/kicad.py
@@ -845,11 +845,6 @@ def _parse_lib_part_kicad_v6(self, get_name_only):
         symbol_name = "_".join(unit_name_pieces[:-2])
         assert symbol_name == self.name
         unit_num = int(unit_name_pieces[-2])
-        conversion_flag = int(unit_name_pieces[-1])
-
-        # Don't add this unit to the part if the conversion flag is 0.
-        if not conversion_flag:
-            continue
 
         # Get the pins for this unit.
         unit_pins = [item for item in unit if to_list(item)[0] == "pin"]


### PR DESCRIPTION
Some symbols files have pin information stored in sections named `NAME_x_0`, which causes skidl not to process this information.

I think the conversion flag is an optimization since many symbols have no pin information stored in `NAME_1_0`. Based on this, and the fact that that pin information is actively parsed in the subsequent lines, and if there is none, processing will skip to the next unit, I think it's safe to remove thel lines as shown in the PR
