### PR TITLE
Update gitignore to the current provided by github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,54 +1,171 @@
-# IntelliJ IDEA & pycharm
-.idea
-
-# virtualenvs
-venv
-
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
-*.bak
+*$py.class
 
 # C extensions
 *.so
 
-# Packages
-*.egg
-*.egg-info
-pip-wheel-metadata/
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
 .installed.cfg
-lib
-lib64
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
+pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
-.tox
+.coverage.*
+.cache
 nosetests.xml
-htmlcov
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
+*.pot
 
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
-
-# Complexity
-output/*.html
-output/*/index.html
-
+# Django stuff:
 *.log
-.cache
-uno_r3
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
 
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Things from the old gitignore that are not in the new one
+output/*.html
+.mr.developer.cfg
+output/*/index.html
+pip-wheel-metadata/
+.pydevproject
 *.erc
+bin
+uno_r3
+*.bak


### PR DESCRIPTION
I noticed that `.venv` was missing from the `.gitignore`, so I went to add it, but figured I may as well update to the latest provided by Github in the process!  

I "diffed" the two files with the following script to see what else to append to the bottom of github's template, then tidied up things that were caught more explicitly:
```
>>> with open('.gitignore') as f:
...   a = f.readlines()
... 
>>> with open('.gitignore2') as f:
...   b = f.readlines()
... 
>>> a = set(a)
>>> b = set(b)
>>> b-a
{'build/\n', 'eggs/\n', '.ipynb_checkpoints\n', '# SageMath parsed files\n', 'venv/\n', '*.manifest\n', '# poetry\n', '.scrapy\n', '#   commonly ignored for libraries.\n', 'downloads/\n', '#poetry.lock\n', '*$py.class\n', '# pdm\n', '#  and can be added to the global gitignore or merged into this file.  For a more nuclear\n', 'db.sqlite3\n', '# Environments\n', 'profile_default/\n', '#   For a library or package, you might want to ignore these files since the code is\n', '#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it\n', '.pybuilder/\n', '.pyre/\n', 'lib/\n', '# Distribution / packaging\n', '# Scrapy stuff:\n', '#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore\n', '.hypothesis/\n', 'instance/\n', '# PyCharm\n', 'celerybeat.pid\n', 'dist/\n', 'ENV/\n', '.venv\n', 'venv.bak/\n', '.webassets-cache\n', '#  option (not recommended) you can uncomment the following to ignore the entire idea folder.\n', '.spyderproject\n', 'env/\n', 'develop-eggs/\n', '# PyBuilder\n', '.pdm.toml\n', '.Python\n', "#   having no cross-platform support, pipenv may install dependencies that don't work, or not\n", '*.spec\n', '# Sphinx documentation\n', '*.egg-info/\n', '#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control\n', '# Pyre type checker\n', 'sdist/\n', '#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.\n', 'db.sqlite3-journal\n', 'lib64/\n', '*.sage.py\n', '#.idea/', '# .python-version\n', '# IPython\n', '#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can\n', '# Celery stuff\n', 'coverage.xml\n', '#   intended to run in multiple environments; otherwise, check them in:\n', '/site\n', '.pytest_cache/\n', '# Rope project settings\n', '.coverage.*\n', '# Byte-compiled / optimized / DLL files\n', '# pyenv\n', '#   in version control.\n', 'ipython_config.py\n', 'wheels/\n', '# mypy\n', '# mkdocs documentation\n', '# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm\n', '.tox/\n', 'env.bak/\n', '.nox/\n', '*.py,cover\n', '#  Usually these files are written by a python script from a template\n', '#  before PyInstaller builds the exe, so as to inject date/other infos into it.\n', '__pycache__/\n', 'target/\n', '#pdm.lock\n', '# Flask stuff:\n', 'dmypy.json\n', 'MANIFEST\n', '# pytype static type analyzer\n', 'parts/\n', '.ropeproject\n', '*.cover\n', '# pipenv\n', '#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.\n', '# PyInstaller\n', '#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.\n', '#   This is especially recommended for binary packages to ensure reproducibility, and is more\n', '.spyproject\n', 'cython_debug/\n', 'htmlcov/\n', 'cover/\n', '.dmypy.json\n', 'docs/_build/\n', '.pytype/\n', '# Cython debug symbols\n', 'pip-delete-this-directory.txt\n', '#   https://pdm.fming.dev/#use-with-ide\n', 'share/python-wheels/\n', '.env\n', 'var/\n', '__pypackages__/\n', '#   install all needed dependencies.\n', '.eggs/\n', 'local_settings.py\n', '.mypy_cache/\n', 'celerybeat-schedule\n', '# Django stuff:\n', '# Jupyter Notebook\n', '# Spyder project settings\n', '#Pipfile.lock\n', '*.pot\n', '#   However, in case of collaboration, if having platform-specific dependencies or dependencies\n'}
>>> for l in (a-b):
...   print(l)
... 
```