### PR TITLE
Modifying init files to allow node function to work in demo notebook.

### DIFF
--- a/skidl/__init__.py
+++ b/skidl/__init__.py
@@ -26,7 +26,7 @@ from __future__ import (  # isort:skip
 )
 from future import standard_library
 
-from . import tools
+from .tools import *
 from .alias import *
 from .arrange import *
 from .bus import *

--- a/skidl/tools/__init__.py
+++ b/skidl/tools/__init__.py
@@ -49,6 +49,11 @@ for module_name in os.listdir(directory):
     # Import the module.
     mod = __import__(module_name, globals(), locals(), [], level=1)
 
+    # Import each non-private attribute from the module.
+    attribute_list = [attribute for attribute in dir(mod) if attribute.startswith('_') is False]
+    for attribute in attribute_list:
+        globals()[attribute] = getattr(mod, attribute)
+
     # Get some info from the imported module.
     try:
         tool_name = getattr(mod, "tool_name")


### PR DESCRIPTION
Hi Dave, thanks for making this project, I think it's super valuable!

This fix will allow the `node` function to be used in the demo notebooks as is.

I considered a few alternatives, open to any of these or other solutions if you prefer. I prefer separate explicit namespacing / imports rather than one global one but I am trying to adhere to the project's existing import pattern. There may also be a better way to do this.

1. No change to the __init__ files, `node` needs to be namespaced with `tools.spice.node`.
2. Only the change to skidl/tools/__init__.py, `node` needs to be namespaced with `spice.node`.
3. Only the change to skidl/tools/spice/__init__.py, `node` needs to be namespaced with `tools.node`.

All namespacing here can be replaced by explicitly importing the appropriately namespaced node.