### PR TITLE
When creating Nets as part of a Bus, create them in a circuit

### DIFF
--- a/src/skidl/bus.py
+++ b/src/skidl/bus.py
@@ -150,7 +150,7 @@ class Bus(SkidlBaseObject):
             if isinstance(obj, int):
                 # Add a number of new nets to the bus.
                 for _ in range(obj):
-                    self.nets.insert(index, Net())
+                    self.nets.insert(index, Net(circuit=obj.circuit))
                 index += obj
             elif isinstance(obj, Net):
                 # Add an existing net to the bus.
@@ -165,7 +165,7 @@ class Bus(SkidlBaseObject):
                     # OK, the pin wasn't already connected to a net,
                     # so create a new net, add it to the bus, and
                     # connect the pin to it.
-                    n = Net()
+                    n = Net(circuit=obj.circuit)
                     n += obj
                     self.nets.insert(index, n)
                 index += 1


### PR DESCRIPTION
When creating Nets as part of extending a Bus, create the nets as part of the circuit of what we want to connect them to, rather than the default circuit. This causes a crash if this functionality is used on a circuit other than the default circuit