### PR TITLE
Fix KiCAD8 var names

### DIFF
--- a/src/skidl/tools/kicad8/lib.py
+++ b/src/skidl/tools/kicad8/lib.py
@@ -48,10 +48,10 @@ def default_lib_paths():
 
     # Add the location of the default KiCad part libraries.
     try:
-        paths.append(os.environ["KICAD7_SYMBOL_DIR"])
+        paths.append(os.environ["KICAD8_SYMBOL_DIR"])
     except KeyError:
         active_logger.warning(
-            "KICAD7_SYMBOL_DIR environment variable is missing, so the default KiCad symbol libraries won't be searched."
+            "KICAD8_SYMBOL_DIR environment variable is missing, so the default KiCad symbol libraries won't be searched."
         )
 
     return paths
@@ -88,11 +88,11 @@ def load_sch_lib(lib, filename=None, lib_search_paths_=None, lib_section=None):
         lib_section: Only used for SPICE simulations.
     """
 
-    from skidl import Part, KICAD7
+    from skidl import Part, KICAD8
     from skidl.tools import lib_suffixes
 
     # Try to open the file using allowable suffixes for the versions of KiCAD.
-    suffixes = lib_suffixes[KICAD7]
+    suffixes = lib_suffixes[KICAD8]
     base, suffix = os.path.splitext(filename)
     if suffix:
         # If an explicit file extension was given, use it instead of tool lib default extensions.
@@ -179,7 +179,7 @@ def load_sch_lib(lib, filename=None, lib_search_paths_=None, lib_section=None):
         lib.add_parts(
             Part(
                 part_defn=part_defn, # A list of lists that define the part.
-                tool=KICAD7,
+                tool=KICAD8,
                 dest=LIBRARY,
                 filename=filename,
                 name=part_name,
@@ -332,7 +332,7 @@ def parse_lib_part(part, partial_parse):
 
         # Return true if the symbol had pins.
         return bool(symbol_pins)
-    
+
     def parse_draw_cmds(symbol):
         '''Return a list of graphic drawing commands contained in the symbol.'''
         return [
@@ -341,7 +341,7 @@ def parse_lib_part(part, partial_parse):
             if item[0].value().lower()
             in ("arc", "bezier", "circle", "pin", "polyline", "rectangle", "text")
         ]
-    
+
     # Parse top-level pins. (Pins in any units are parsed later.)
     parse_pins(part.part_defn, unit_id="main")
 

--- a/tests/unit_tests/test_cmds.py
+++ b/tests/unit_tests/test_cmds.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from skidl import search, set_default_tool, KICAD, KICAD6, KICAD7
+from skidl import search, set_default_tool, KICAD, KICAD6, KICAD7, KICAD8
 
 from .setup_teardown import setup_function, teardown_function
 
@@ -23,6 +23,12 @@ def test_search_2(capfd):
 
 def test_search_3(capfd):
     set_default_tool(KICAD7)
+    search("ESP32")  # Should find 6 matches in RF_Module.kicad_sym.
+    out, err = capfd.readouterr()
+    assert out.count("RF_Module.kicad_sym:") == 6
+
+def test_search_4(capfd):
+    set_default_tool(KICAD8)
     search("ESP32")  # Should find 6 matches in RF_Module.kicad_sym.
     out, err = capfd.readouterr()
     assert out.count("RF_Module.kicad_sym:") == 6

--- a/tests/unit_tests/test_lib.py
+++ b/tests/unit_tests/test_lib.py
@@ -12,6 +12,7 @@ from skidl import (
     KICAD,
     KICAD6,
     KICAD7,
+    KICAD8,
     SKIDL,
     TEMPLATE,
     Part,
@@ -31,7 +32,7 @@ from .setup_teardown import setup_function, teardown_function
 def test_missing_lib():
     # Sometimes, loading a part from a non-existent library doesn't throw an
     # exception until the second time it's tried. This detects that error.
-    
+
     # Don't allow searching backup lib that might exist from previous tests.
     SchLib.reset()
     skidl.config.query_backup_lib=False


### PR DESCRIPTION
While trying to run a the README example for kicad8 (#179) I noticed the var names in kicad8/lib.py were wrong. It's still complaining about `KICAD8_SYMBOL_DIR` env var missing, is that user error?

```
$ cat test.py
#!/usr/bin/env python3

import os
import sys
from skidl import KICAD8
from skidl import set_default_tool
from skidl import lib_search_paths
from skidl import footprint_search_paths
from skidl import TEMPLATE
from skidl import Part
from skidl import Net
from skidl import generate_netlist
from skidl import generate_pcb

os.environ["KICAD8_SYMBOL_DIR"] = "/usr/share/kicad/symbols/"
set_default_tool(KICAD8)

lib_search_paths[KICAD8].append('/usr/share/kicad/symbols')
footprint_search_paths[KICAD8].append('/usr/share/kicad/footprints')
print(f"{footprint_search_paths=}", file=sys.stderr)

# Create part templates.
q = Part("Device", "Q_PNP_CBE", dest=TEMPLATE)
r = Part("Device", "R", dest=TEMPLATE)

# Create nets.
gnd, vcc = Net("GND"), Net("VCC")
a, b, a_and_b = Net("A"), Net("B"), Net("A_AND_B")

# Instantiate parts.
gndt = Part("power", "GND")             # Ground terminal.
vcct = Part("power", "VCC")             # Power terminal.
q1, q2 = q(2)                           # Two transistors.
r1, r2, r3, r4, r5 = r(5, value="10K")  # Five 10K resistors.

# Make connections between parts.
# ptlint:
a & r1 & q1["B C"] & r4 & q2["B C"] & a_and_b & r5 & gnd
b & r2 & q1["B"]
q1["C"] & r3 & gnd
vcc += q1["E"], q2["E"], vcct
gnd += gndt

generate_netlist()

$ ./test.py
WARNING: KICAD_SYMBOL_DIR environment variable is missing, so the default KiCad symbol libraries won't be searched. @ [/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap_external>:940=>/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap>:241]
WARNING: KICAD7_SYMBOL_DIR environment variable is missing, so the default KiCad symbol libraries won't be searched. @ [/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap_external>:940=>/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap>:241]
WARNING: KICAD8_SYMBOL_DIR environment variable is missing, so the default KiCad symbol libraries won't be searched. @ [/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap_external>:940=>/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap>:241]
WARNING: KICAD6_SYMBOL_DIR environment variable is missing, so the default KiCad symbol libraries won't be searched. @ [/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap_external>:940=>/home/cfg/cad/skidl/bug_179/<frozen importlib._bootstrap>:241]
footprint_search_paths={'kicad': ['/home/user/.config/kicad'], 'kicad7': ['/home/user/.config/kicad'], 'kicad8': ['/home/user/.config/kicad', '/usr/share/kicad/footprints'], 'skidl': ['/home/user/.config/kicad'], 'kicad6': ['/home/user/.config/kicad'], 'spice': ['/home/user/.config/kicad']}
WARNING: Could not load KiCad schematic library "Device", falling back to backup library. @ [/home/cfg/cad/skidl/bug_179/example_from_readme_bug_179.py:23]
WARNING: Could not load KiCad schematic library "Device", falling back to backup library. @ [/home/cfg/cad/skidl/bug_179/example_from_readme_bug_179.py:24]
WARNING: Could not load KiCad schematic library "power", falling back to backup library. @ [/home/cfg/cad/skidl/bug_179/example_from_readme_bug_179.py:31]
WARNING: Could not load KiCad schematic library "power", falling back to backup library. @ [/home/cfg/cad/skidl/bug_179/example_from_readme_bug_179.py:32]
INFO: No errors or warnings found while generating netlist.


```